### PR TITLE
Add config handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +498,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
+name = "papergrid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1526bb6aa9f10ec339fb10360f22c57edf81d5678d0278e93bc12a47ffbe4b01"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +761,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c3ee73732ffceaea7b8f6b719ce3bb17f253fa27461ffeaf568ebd0cdb4b85"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beca1b4eaceb4f2755df858b88d9b9315b7ccfd1ffd0d7a48a52602301f01a57"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +928,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +961,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tabled",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ reqwest = "0.11.12"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 serde_yaml = "0.9.14"
+tabled = { version = "0.10.0", features = ["derive"] }
 tracing = "0.1.37"

--- a/src/api/config/config.rs
+++ b/src/api/config/config.rs
@@ -42,7 +42,11 @@ fn save_config(config: &Config) -> Result<()> {
 
   let result = match home::home_dir() {
     Some(home) => {
-      let path = home.join(".vc4/config.yaml").clone();
+      let path = home.join(".vc4/config.yaml");
+
+      if !path.exists() {
+        std::fs::File::create(path.clone())?;
+      }
 
       match std::fs::write(path, contents) {
         Ok(()) => Ok(()),

--- a/src/api/config/config.rs
+++ b/src/api/config/config.rs
@@ -1,8 +1,11 @@
-use std::{path::{PathBuf, Path}, any};
+use std::path::PathBuf;
 use serde::{Serialize, Deserialize};
 use anyhow::{Context, Result, anyhow};
+use tabled::Tabled;
 
-#[derive(Serialize, Deserialize, Debug)]
+use crate::cli::cli::{ConfigUpdateArgs, ConfigRemoveArgs, ConfigAddArgs, ConfigUseArgs};
+
+#[derive(Serialize, Deserialize, Debug, Tabled)]
 pub struct Server {
   url: String,
   name: String,
@@ -19,22 +22,77 @@ pub struct Config {
   servers: Vec<Server>
 }
 
-pub fn add_server(name: &str, url:&str, token:&str) -> anyhow::Result<()>{
-  let mut config = get_config()?;
+pub fn add_server(args:ConfigAddArgs) -> Result<()>{
+  let mut config = get_config().with_context(|| "Unable to retrieve config")?;
 
+  if config.servers.iter().any(|n| n.name == args.name) {    
+    return Err(anyhow!("Unable to add server with name {}. Server with that name already exists", args.name));
+  } 
+  
   let new_server = Server {
-    url: url.to_string(),
-    name: name.to_string(),
-    token: token.to_string()
+    url: args.url,
+    name: args.name,
+    token: args.token
   };
 
   config.servers.push(new_server);    
 
-  return save_config(&config);
+  save_config(&config)
 }
 
-pub fn update_server(name: &str, host: &str, token: &str){
-  println!("{} {} {}", name, host, token)
+pub fn remove_server(args: &ConfigRemoveArgs) -> Result<()> {
+  let mut config = get_config().with_context(||"Unable to retrieve config")?;
+
+  if config.current_server == args.name {
+    config.current_server = "".to_string();
+  }
+
+  config.servers.retain(|s| s.name != args.name);
+
+  save_config(&config)
+}
+
+pub fn update_server(args: &ConfigUpdateArgs) -> Result<()> {
+  let mut config = get_config().with_context(||"Unable to retrieve config")?;
+
+  let mut current_server = config.servers.remove(config.servers.iter().position(|s| s.name == args.name)
+    .with_context(|| format!("Server with name {} not found", args.name))?);  
+    
+  match &args.url {
+    Some(url) => current_server.url = url.to_string(),
+    None => (),
+  }
+
+  match &args.token {
+    Some(token) => current_server.token = token.to_string(),
+    None => ()
+  }
+
+  config.servers.push(current_server);
+
+  save_config(&config)
+}
+
+pub fn use_server(args: ConfigUseArgs) -> Result<()> {
+  let mut config = get_config().with_context(|| "Unable to retrieve config")?;
+
+  if !config.servers.iter().any(|s| s.name == args.name) {
+    return Err(anyhow!("Server with name {} does not exist. Please add it before trying to use it.", args.name));
+  }
+
+  config.current_server = args.name;
+  
+  save_config(&config)
+}
+
+pub fn get_servers() -> Result<()> {
+  let config = get_config().with_context(||"Unable to retrieve config")?;
+
+  let table = tabled::Table::new(config.servers).to_string();
+
+  print!("{}", table);
+
+  Ok(())
 }
 
 fn save_config(config: &Config) -> Result<()> {
@@ -42,19 +100,27 @@ fn save_config(config: &Config) -> Result<()> {
 
   let result = match home::home_dir() {
     Some(home) => {
-      let path = home.join(".vc4/config.yaml");
+      let config_folder = home.join(".vc4");
 
+      let path = config_folder.join("config.yaml");
+
+      if !config_folder.exists() {
+        std::fs::create_dir(config_folder.clone()).with_context(||"Unable to create config directory")?;         
+      }
+      
       if !path.exists() {
-        std::fs::File::create(path.clone())?;
+        std::fs::File::create(path.clone()).with_context(||"Unable to create config file")?;
       }
 
       match std::fs::write(path, contents) {
         Ok(()) => Ok(()),
-        Err(error) => Err(anyhow!(error))
+        Err(error) => Err(anyhow!("Unable to write config: {}", error))
       }
+      
     },
     None => Err(anyhow!("Unable to find home directory"))
-  };
+  }; 
+  
   result
 }
 
@@ -64,7 +130,7 @@ fn get_config() -> Result<Config> {
       let yaml = std::fs::read_to_string(&config_path)
       .with_context(|| "Found config.yaml, but unable to read the contents")?;
 
-      let mut config = match yaml.trim().is_empty() {
+      let config = match yaml.trim().is_empty() {
         true => Config {
           ..Default::default()
         },
@@ -85,7 +151,7 @@ fn get_config_file_exists() -> Option<PathBuf> {
   if let Some(home) = home::home_dir() {
     let config = home.join(".vc4/config.yaml");
 
-    if config.is_file() {
+    if config.is_file() {      
       return Some(config);
     }
   }

--- a/src/api/config/config.rs
+++ b/src/api/config/config.rs
@@ -1,0 +1,90 @@
+use std::{path::{PathBuf, Path}, any};
+use serde::{Serialize, Deserialize};
+use anyhow::{Context, Result, anyhow};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Server {
+  url: String,
+  name: String,
+  token: String
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct Config {
+  #[serde(default)]
+  #[serde(rename = "current-server")]
+  current_server: String,
+
+  #[serde(default)]
+  servers: Vec<Server>
+}
+
+pub fn add_server(name: &str, url:&str, token:&str) -> anyhow::Result<()>{
+  let mut config = get_config()?;
+
+  let new_server = Server {
+    url: url.to_string(),
+    name: name.to_string(),
+    token: token.to_string()
+  };
+
+  config.servers.push(new_server);    
+
+  return save_config(&config);
+}
+
+pub fn update_server(name: &str, host: &str, token: &str){
+  println!("{} {} {}", name, host, token)
+}
+
+fn save_config(config: &Config) -> Result<()> {
+  let contents = serde_yaml::to_string(config)?;
+
+  let result = match home::home_dir() {
+    Some(home) => {
+      let path = home.join(".vc4/config.yaml").clone();
+
+      match std::fs::write(path, contents) {
+        Ok(()) => Ok(()),
+        Err(error) => Err(anyhow!(error))
+      }
+    },
+    None => Err(anyhow!("Unable to find home directory"))
+  };
+  result
+}
+
+fn get_config() -> Result<Config> {
+  let config = match get_config_file_exists() {
+    Some(config_path) => {
+      let yaml = std::fs::read_to_string(&config_path)
+      .with_context(|| "Found config.yaml, but unable to read the contents")?;
+
+      let mut config = match yaml.trim().is_empty() {
+        true => Config {
+          ..Default::default()
+        },
+        false => serde_yaml::from_str(yaml.as_str()).with_context(|| "Found config.yaml, but unable to deserialize")?,
+      };
+
+      config
+    },
+    None => Config {
+      ..Default::default()
+    }
+  };
+
+  Ok(config)
+}
+
+fn get_config_file_exists() -> Option<PathBuf> {
+  if let Some(home) = home::home_dir() {
+    let config = home.join(".vc4/config.yaml");
+
+    if config.is_file() {
+      return Some(config);
+    }
+  }
+
+  None
+}

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand, Args};
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(author, version)]
 #[command(about="vc4ctl - a CLI for interacting with Crestron VC-4 servers")]
 pub struct Cli {
@@ -8,19 +8,19 @@ pub struct Cli {
     pub command: Option<Commands>,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Configure server information
     Config(Config),
 }
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 pub struct Config {
   #[command(subcommand)]
   pub config_commands:Option<ConfigCommands>,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum ConfigCommands {
   Add(ConfigAddArgs),  
   Use(ConfigUseArgs),
@@ -29,31 +29,35 @@ pub enum ConfigCommands {
   GetServers(ConfigGetServersArgs),
 }
 
-#[derive(Args)]
+#[derive(Args, Debug, Clone)]
 pub struct ConfigAddArgs {
   pub name: String,
   pub url: String,  
   pub token: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug, Clone)]
 pub struct ConfigUseArgs {
   pub name: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct ConfigRemoveArgs {
   pub name: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct ConfigUpdateArgs {
   pub name: String,
-  pub url: String,
-  pub token: String,
+
+  #[arg(short='u', long="url")]
+  pub url: Option<String>,
+
+  #[arg(short='t', long="token")]
+  pub token: Option<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct ConfigGetServersArgs {
   
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,23 +13,47 @@ fn main() -> anyhow::Result<()>{
         Some(Commands::Config(args)) => {
             match &args.config_commands {
                 Some(ConfigCommands::Add(args)) => {
-                    match config::config::add_server(&args.name, &args.url, &args.token ) {
-                        Ok(()) => {return Ok(());}
+                    match config::config::add_server(args.clone()) {
+                        Ok(()) => {
+                            println!("Server {} successfully added", args.name);
+                            return Ok(());}
                         Err(error) => return Err(anyhow::anyhow!(error))
                     }                
                 }
                 Some(ConfigCommands::Remove(args)) => {
-                    println!("{}", args.name);
-                    
+                    match config::config::remove_server(args) {
+                        Ok(()) => {
+                            println!("Server {} successfully removed", args.name);
+                            return Ok(());
+                        }
+                        Err(error) => return Err(anyhow::anyhow!(error))
+                    }                    
                 }
                 Some(ConfigCommands::Update(args)) => {
-                    println!("{}", args.name);
+                    match config::config::update_server(args) {
+                        Ok(()) => {
+                            println!("Server {} successfully updated", args.name);
+                            return Ok(());
+                        }
+                        Err(error) => return Err(anyhow::anyhow!(error))
+                    }
                 }
                 Some(ConfigCommands::Use(args)) => {
-                    println!("{}", args.name);
+                    match config::config::use_server(args.clone()){
+                        Ok(()) => {
+                            println!("Using Server {}", args.name);
+                            return Ok(());
+                        }
+                        Err(error) => return Err(anyhow::anyhow!(error))
+                    }
                 }
                 Some(ConfigCommands::GetServers(_args)) => {
-                    println!("GetServers")
+                    match config::config::get_servers() {
+                        Ok(()) => {                            
+                            return Ok(());
+                        }
+                        Err(error) => return Err(anyhow::anyhow!(error))
+                    }
                 }
                 None => {
                     return Err(anyhow::anyhow!("No valid arguments"));


### PR DESCRIPTION
Initial implementation of CRUD operations for VC-4 servers. When the first server is added, a file will be created at `~/.vc4/config.yaml`. On Windows, this will most likely result in the folder being created at `c:/users/{username}`. On Linux, the folder will be in the `/home/{username}` folder.

All operations are under the `vc4ctl config` command, and the following commands are supported:
* `add <name> <url> <token>`
* `remove <name>`
* `use <name>`
* `update <name> --token <token> --url <url>`
* `get-servers`

## Example
```
vc4ctl config add test https://myUrl myToken
vc4ctl config use test
```